### PR TITLE
Gradle 8 Migration for Expo 49 SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,19 +35,13 @@ buildscript {
   }
 }
 
-// Creating sources with comments
-task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
-  from android.sourceSets.main.java.srcDirs
-}
-
 afterEvaluate {
   publishing {
     publications {
       release(MavenPublication) {
         from components.release
         // Add additional sourcesJar to artifacts
-        artifact(androidSourcesJar)
+        //artifact(androidSourcesJar)
       }
     }
     repositories {
@@ -78,6 +72,11 @@ android {
   }
   lintOptions {
     abortOnError false
+  }
+  publishing{
+    singleVariant("release"){
+      withSourcesJar()
+    }
   }
 }
 


### PR DESCRIPTION
After the Expo 49 SDK, All Expo Modules has to use Gradle 8. I fixed this problem with using the article:
https://blog.expo.dev/expo-sdk-49-c6d398cdf740