### PR TITLE
[Android] Updating application meta-data key to init the Places API

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+[Description of the pull request]
+
+## Proposed Changes
+
+[Description of the proposed changes]
+
+## Related Issues
+
+<!-- [List of issues related to this pull request, if any] -->
+
+None.
+
+## Additional Comments
+
+<!-- [Additional comments or extra information, if any] -->
+
+None.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 group = 'expo.modules.googleplaces'
-version = '0.2.3'
+version = '0.2.4'
 
 buildscript {
   def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")

--- a/android/src/main/java/expo/modules/googleplaces/ExpoGooglePlacesModule.kt
+++ b/android/src/main/java/expo/modules/googleplaces/ExpoGooglePlacesModule.kt
@@ -24,13 +24,13 @@ class ExpoGooglePlacesModule : Module() {
     OnCreate {
       val packageName = appContext?.reactContext?.packageName.toString()
       val applicationInfo = appContext?.reactContext?.packageManager?.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-      val placesApiKey = applicationInfo?.metaData?.getString("com.google.android.geo.API_KEY")
+      val placesApiKey = applicationInfo?.metaData?.getString("com.google.android.geo.PLACES_API_KEY")
 
       Places.initialize(appContext.reactContext, placesApiKey)
 
       if (Places.isInitialized()) {
         placesClient = Places.createClient(appContext.reactContext)
-        Log.d("ExpoGooglePlaces", "The com.google.android.geo.API_KEY was provided successfully. PlacesClient initialized")
+        Log.d("ExpoGooglePlaces", "The com.google.android.geo.PLACES_API_KEY was provided successfully. PlacesClient initialized")
       }
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,3 +10,9 @@ This is the log of notable changes to the Expo Google Places library. Is recomme
 #### Support for Expo SDK 49
 
 - The `android/build.gradle` file has been updated to support Expo SDK 49 following the [Gradle Migration](https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md) guide published by Expo. ([#8](https://github.com/devpgcs/expo-google-places/pull/8) by [@fukuli053](https://github.com/fukuli053))
+
+## v0.2.4 - 2023-10-26
+
+#### Support when also using React Native Maps library
+
+- If you're using the [React Native Maps](https://github.com/react-native-maps/react-native-maps) library you must update the Expo Google Places library to a version **>= 0.2.4** since the versions **<= 0.2.3** use the application meta-data with `com.google.android.geo.API_KEY` key to initialize the Google Places library. This key is also used by the React Native Maps library to initialize the Google Maps library and this causes a conflict between the two libraries.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,14 +5,15 @@ title: Changelog
 
 This is the log of notable changes to the Expo Google Places library. Is recommended to check this page before updating the library to a new version.
 
+## v0.2.4 - 2023-10-26
+
+#### Support when also using React Native Maps library
+
+- If you're using the [React Native Maps](https://github.com/react-native-maps/react-native-maps) library you must update the Expo Google Places library to the version **>= 0.2.4** since the versions **<= 0.2.3** use an application meta-data with `com.google.android.geo.API_KEY` key to initialize the Expo Google Places library. This key is also used by the React Native Maps library to initialize the Google Maps library and this causes a conflict between the two libraries due to overwrites.
+- If you still want to share the same API key for both libraries you must restrict it to the **Maps SDK for Android** and **Places API**. This is required for the Expo Google Places with a version **<= 0.2.3**.
+
 ## v0.2.3 - 2023-10-20
 
 #### Support for Expo SDK 49
 
 - The `android/build.gradle` file has been updated to support Expo SDK 49 following the [Gradle Migration](https://github.com/expo/fyi/blob/main/expo-modules-gradle8-migration.md) guide published by Expo. ([#8](https://github.com/devpgcs/expo-google-places/pull/8) by [@fukuli053](https://github.com/fukuli053))
-
-## v0.2.4 - 2023-10-26
-
-#### Support when also using React Native Maps library
-
-- If you're using the [React Native Maps](https://github.com/react-native-maps/react-native-maps) library you must update the Expo Google Places library to a version **>= 0.2.4** since the versions **<= 0.2.3** use the application meta-data with `com.google.android.geo.API_KEY` key to initialize the Google Places library. This key is also used by the React Native Maps library to initialize the Google Maps library and this causes a conflict between the two libraries.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -13,9 +13,7 @@ If your application requires Place Details such as the place name, business stat
 
 <br>
 
-<video width="100%" controls muted>
-    <source src="./assets/per-session-example.mp4" type="video/mp4" />
-</video>
+<iframe width="100%" height="500" src="https://www.youtube.com/embed/kW61cYf_-PA?si=7Cz_b-R-jvUthDM-" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-google-places",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Expo library to use the Google Places API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -21,7 +21,7 @@ const withGoogleApiKey: ConfigPlugin<ExpoGooglePlacesPluginInput> = (config, plu
         // We're using this constant name because it's the recommended one by Google.
         // in the following documentation: https://developers.google.com/maps/documentation/places/android-sdk/config#get-an-api-key
         // check the NOTE under the step 6.
-        `com.google.android.geo.API_KEY`,
+        `com.google.android.geo.PLACES_API_KEY`,
         pluginInput.androidApiKey!
       );
 


### PR DESCRIPTION
## Description

When using the [React Native Maps](https://github.com/react-native-maps/react-native-maps) library and Expo Google Places library together but, with different API keys... The **prebuild process** is overwriting one of them so, one of the following is happening:

- The Google Map is not being rendered.
- The Places API throws an error.

## Proposed Changes

- The application meta-data key to init the Places API on Android has been updated from `com.google.android.geo.API_KEY` to `com.google.android.geo.PLACES_API_KEY` to avoid the overwrite issue.
- The changelog docs have been updated to let new installers know about it and how to solve the issue.

## Related Issues

<!-- [List of issues related to this pull request, if any] -->

None.

## Additional Comments

The demo video in the **Per Session (session-based) approach** guide has been removed from the source code and it has been uploaded to YouTube to improve the package size.
